### PR TITLE
Fix spread syntax and export styles for combat sandbox

### DIFF
--- a/packages/combat-sandbox/README.md
+++ b/packages/combat-sandbox/README.md
@@ -1,0 +1,74 @@
+# @tba-worldswithin/combat-sandbox
+
+A drop-in React component that re-creates the **Worlds Within** combat sandbox. It exposes the fully interactive toy combat arena plus
+utilities and data definitions so that systems can experiment with the ability catalogue, elemental resonances, and combat pacing.
+
+## Installation
+
+```bash
+npm install @tba-worldswithin/combat-sandbox lucide-react
+```
+
+The component expects `react` and `react-dom` as peer dependencies (React 17 or newer).
+
+## Usage
+
+```jsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import CombatSandbox from '@tba-worldswithin/combat-sandbox';
+
+import '@tba-worldswithin/combat-sandbox/styles.css'; // Provide your own Tailwind/TW-compat styles
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<CombatSandbox />);
+```
+
+The sandbox uses Tailwind-style utility classes. When embedding into an existing project make sure those classes resolve to actual styles (for example by running Tailwind with the configuration that matches the demo site or by translating the classes into your own CSS).
+
+## API
+
+### `CombatSandbox`
+
+```ts
+function CombatSandbox(props?: {
+  initialCharacterState?: CharacterState;
+  initialEnemyState?: EnemyState;
+  abilityLoadout?: AbilityLoadout;
+}): JSX.Element;
+```
+
+* **initialCharacterState** – override the default player state.
+* **initialEnemyState** – provide a custom enemy baseline.
+* **abilityLoadout** – provide ids for the default abilities shown in the four combat lanes.
+
+### Data & helpers
+
+The package re-exports the data tables and helper utilities used by the sandbox:
+
+```js
+import {
+  ABILITIES,
+  ATTRIBUTES,
+  ELEMENTS,
+  WEAPONS,
+  calculateERCost,
+  calculateDamage,
+  calculateResonance,
+  characterReducer,
+  enemyReducer
+} from '@tba-worldswithin/combat-sandbox';
+```
+
+These exports make it possible to build additional tooling (spreadsheets, analysis dashboards, etc.) without coupling to the UI.
+
+## Styling
+
+The demo intentionally relies on Tailwind-style utility classes to keep the package framework-agnostic. Consumers can either:
+
+1. Pull in the Tailwind setup from the Worlds Within demo, or
+2. Map the used classes to their design system using CSS modules, vanilla CSS, or another utility-first framework.
+
+## License
+
+MIT © 2024 Worlds Within Prototype

--- a/packages/combat-sandbox/package.json
+++ b/packages/combat-sandbox/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tba-worldswithin/combat-sandbox",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "exports": {
+    ".": {
+      "import": "./src/index.js"
+    },
+    "./styles.css": "./styles.css",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./styles.css"],
+  "peerDependencies": {
+    "react": ">=17",
+    "react-dom": ">=17"
+  },
+  "dependencies": {
+    "lucide-react": "^0.360.0"
+  }
+}

--- a/packages/combat-sandbox/src/constants.js
+++ b/packages/combat-sandbox/src/constants.js
@@ -1,0 +1,120 @@
+export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA'];
+
+export const ELEMENTS = ['Fire', 'Water', 'Stone', 'Air', 'Spark', 'Verdant', 'Essence'];
+
+export const WEAPONS = {
+  'Long Swords': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.36, recoveryBase: 0.48, erGainedOnHit: 4 },
+  'Curved Long Blades': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.34, recoveryBase: 0.48, erGainedOnHit: 4 },
+  'Short Swords': { mass: 1, damageMultiplier: 0.9, windUpBase: 0.28, recoveryBase: 0.38, erGainedOnHit: 3 },
+  'Great Swords': { mass: 3, damageMultiplier: 1.3, windUpReduction: 0.08, windUpBase: 0.405, recoveryBase: 0.60, erGainedOnHit: 6 },
+  'Knives & Daggers': { mass: 1, damageMultiplier: 0.85, windUpBase: 0.26, recoveryBase: 0.36, erGainedOnHit: 2 },
+  'Fist Weapons': { mass: 1, damageMultiplier: 0.85, windUpBase: 0.26, recoveryBase: 0.34, erGainedOnHit: 2 },
+  'One-Hand Axes': { mass: 2, damageMultiplier: 1.1, windUpBase: 0.38, recoveryBase: 0.52, erGainedOnHit: 4 },
+  'Two-Hand Axes': { mass: 3, damageMultiplier: 1.35, windUpBase: 0.46, recoveryBase: 0.62, erGainedOnHit: 6 },
+  'Spears (Thrusting)': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.36, recoveryBase: 0.48, erGainedOnHit: 4 },
+  'Polearms (Sweeping)': { mass: 2, damageMultiplier: 1.05, windUpBase: 0.40, recoveryBase: 0.52, erGainedOnHit: 4 },
+  'Blunt Weapons': { mass: 3, damageMultiplier: 1.35, windUpBase: 0.46, recoveryBase: 0.64, erGainedOnHit: 6 },
+  'Flails & Chain Maces': { mass: 2, damageMultiplier: 1.1, windUpBase: 0.36, recoveryBase: 0.52, erGainedOnHit: 4 },
+  'Whips & Urumi': { mass: 1, damageMultiplier: 0.9, windUpBase: 0.32, recoveryBase: 0.50, erGainedOnHit: 2 },
+  'Staffs': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.38, recoveryBase: 0.50, erGainedOnHit: 4 },
+  'Shields': { mass: 2, damageMultiplier: 0.8, windUpBase: 0.32, recoveryBase: 0.42, erGainedOnHit: 4 },
+  'Longbows': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.42, recoveryBase: 0.52, erGainedOnHit: 4 },
+  'Short Bows': { mass: 1, damageMultiplier: 0.9, windUpBase: 0.34, recoveryBase: 0.46, erGainedOnHit: 3 },
+  'Crossbows': { mass: 2, damageMultiplier: 1.1, windUpBase: 0.42, recoveryBase: 0.56, erGainedOnHit: 4 },
+  'Pistols': { mass: 2, damageMultiplier: 1.0, windUpBase: 0.42, recoveryBase: 0.56, erGainedOnHit: 4 },
+  'Shotguns': { mass: 2, damageMultiplier: 1.2, windUpBase: 0.42, recoveryBase: 0.60, erGainedOnHit: 4 },
+  'Long Guns': { mass: 3, damageMultiplier: 1.25, windUpBase: 0.50, recoveryBase: 0.65, erGainedOnHit: 6 },
+  'Thrown Weapons': { mass: 1, damageMultiplier: 0.95, windUpBase: 0.30, recoveryBase: 0.42, erGainedOnHit: 2 },
+  'Misc. Ranged': { mass: 1, damageMultiplier: 0.9, windUpBase: 0.32, recoveryBase: 0.46, erGainedOnHit: 2 }
+};
+
+export const COMBAT_STATES = { IDLE: 'idle', WIND_UP: 'windUp', RECOVERY: 'recovery' };
+
+export const ABILITIES = [
+  { id: 'fire_attack', name: 'Embernick', family: 'Fire', variant: 'Attack', baseBand: 5, baseDamage: 10, governingAttr: 'STR', governingElem: 'Fire', scalars: { scope: 1.0, potency: 1.1, uptime: 1.0, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.0 }, description: 'Fire strike' },
+  { id: 'fire_defense', name: 'Ember Mantle', family: 'Fire', variant: 'Defense', baseBand: 5, baseDamage: 5, mitigationMultiplier: 0.50, governingAttr: 'TOU', governingElem: 'Fire', scalars: { scope: 1.0, potency: 1.0, uptime: 1.0, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.90 }, description: '50% mitigation', duration: 2000 },
+  { id: 'fire_control', name: 'Ember Haze', family: 'Fire', variant: 'Control', baseBand: 12, baseDamage: 6, governingAttr: 'DEX', governingElem: 'Fire', scalars: { scope: 1.0, potency: 1.0, uptime: 1.0, reliability: 0.98, mobility: 1.0, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.0 }, description: '1.25s Slow', ccDuration: 1.25, ccType: 'Slow' },
+  { id: 'fire_special', name: 'Blazereap', family: 'Fire', variant: 'Special', baseBand: 28, baseDamage: 40, governingAttr: 'STR', governingElem: 'Fire', scalars: { scope: 1.25, potency: 1.35, uptime: 1.0, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 1.0 }, description: 'Cone (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'fire_safe_attack', name: 'Flicker', family: 'Fire', variant: 'Attack', baseBand: 3, baseDamage: 7, governingAttr: 'DEX', governingElem: 'Fire', scalars: { scope: 1.0, potency: 0.85, uptime: 1.0, reliability: 1.0, mobility: 1.10, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.85 }, description: 'Safe jab' },
+  { id: 'fire_heavy_defense', name: 'Ember-Plate', family: 'Fire', variant: 'Defense', baseBand: 7, baseDamage: 8, mitigationMultiplier: 0.35, governingAttr: 'TOU', governingElem: 'Fire', scalars: { scope: 1.0, potency: 1.10, uptime: 1.30, reliability: 1.0, mobility: 0.85, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.80 }, description: '65% mitigation', duration: 3000 },
+  { id: 'fire_agg_attack', name: 'Emberstorm', family: 'Fire', variant: 'Attack', baseBand: 8, baseDamage: 18, governingAttr: 'STR', governingElem: 'Fire', scalars: { scope: 1.15, potency: 1.30, uptime: 1.0, reliability: 1.0, mobility: 0.90, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 1.10 }, description: 'Aggressive AoE' },
+  { id: 'water_attack', name: 'Rippletap', family: 'Water', variant: 'Attack', baseBand: 5, baseDamage: 9, governingAttr: 'SPR', governingElem: 'Water', scalars: { scope: 1.0, potency: 1.05, uptime: 1.15, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 1.0 }, description: 'Water strike' },
+  { id: 'water_defense', name: 'Steamscreen', family: 'Water', variant: 'Defense', baseBand: 6, baseDamage: 4, mitigationMultiplier: 0.60, governingAttr: 'TOU', governingElem: 'Water', scalars: { scope: 1.0, potency: 0.95, uptime: 1.20, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.92 }, description: '60% mitigation', duration: 2000 },
+  { id: 'water_control', name: 'Drift Hold', family: 'Water', variant: 'Control', baseBand: 13, baseDamage: 5, governingAttr: 'SPR', governingElem: 'Water', scalars: { scope: 1.05, potency: 0.95, uptime: 1.10, reliability: 1.0, mobility: 1.0, ccCap: 1.05, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: '1.5s Slow', ccDuration: 1.5, ccType: 'Slow' },
+  { id: 'water_safe_attack', name: 'Measure', family: 'Water', variant: 'Attack', baseBand: 3, baseDamage: 6, governingAttr: 'SPR', governingElem: 'Water', scalars: { scope: 1.0, potency: 0.80, uptime: 1.20, reliability: 1.0, mobility: 1.05, ccCap: 1.0, reaction: 1.05, cooldown: 1.0, risk: 0.85 }, description: 'Sustained poke' },
+  { id: 'water_heavy_defense', name: 'Sunken Aegis', family: 'Water', variant: 'Defense', baseBand: 7, baseDamage: 6, mitigationMultiplier: 0.30, governingAttr: 'TOU', governingElem: 'Water', scalars: { scope: 1.0, potency: 0.85, uptime: 1.40, reliability: 1.0, mobility: 0.80, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 0.75 }, description: '70% mitigation', duration: 3500 },
+  { id: 'stone_attack', name: 'Ironkiss', family: 'Stone', variant: 'Attack', baseBand: 6, baseDamage: 12, governingAttr: 'STR', governingElem: 'Stone', scalars: { scope: 1.0, potency: 1.20, uptime: 1.0, reliability: 1.0, mobility: 0.95, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.05 }, description: 'Heavy strike' },
+  { id: 'stone_defense', name: 'Ironbark Hold', family: 'Stone', variant: 'Defense', baseBand: 4, baseDamage: 3, mitigationMultiplier: 0.40, governingAttr: 'TOU', governingElem: 'Stone', scalars: { scope: 1.0, potency: 0.90, uptime: 1.25, reliability: 1.0, mobility: 0.90, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.85 }, description: '60% mitigation', duration: 2500 },
+  { id: 'stone_control', name: 'Ground-Lock', family: 'Stone', variant: 'Control', baseBand: 14, baseDamage: 7, governingAttr: 'TOU', governingElem: 'Stone', scalars: { scope: 1.0, potency: 1.05, uptime: 1.0, reliability: 1.0, mobility: 0.95, ccCap: 1.10, reaction: 1.0, cooldown: 1.0, risk: 1.0 }, description: '1.75s Root', ccDuration: 1.75, ccType: 'Root' },
+  { id: 'stone_safe_attack', name: 'Halfguard', family: 'Stone', variant: 'Attack', baseBand: 4, baseDamage: 9, governingAttr: 'STR', governingElem: 'Stone', scalars: { scope: 1.0, potency: 0.95, uptime: 1.0, reliability: 1.0, mobility: 0.90, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.80 }, description: 'Defensive strike' },
+  { id: 'stone_agg_attack', name: 'Quakeblade', family: 'Stone', variant: 'Attack', baseBand: 9, baseDamage: 22, governingAttr: 'STR', governingElem: 'Stone', scalars: { scope: 1.10, potency: 1.40, uptime: 1.0, reliability: 1.0, mobility: 0.80, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.15 }, description: 'Heavy slam' },
+  { id: 'stone_heavy_defense', name: 'Granite-Lock', family: 'Stone', variant: 'Defense', baseBand: 6, baseDamage: 5, mitigationMultiplier: 0.25, governingAttr: 'TOU', governingElem: 'Stone', scalars: { scope: 1.0, potency: 0.80, uptime: 1.50, reliability: 1.0, mobility: 0.70, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 0.70 }, description: '75% mitigation', duration: 4000 },
+  { id: 'air_attack', name: 'Galespike', family: 'Air', variant: 'Attack', baseBand: 4, baseDamage: 8, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.0, potency: 1.0, uptime: 1.0, reliability: 0.98, mobility: 1.15, ccCap: 1.0, reaction: 1.05, cooldown: 1.0, risk: 0.95 }, description: 'Swift strike' },
+  { id: 'air_defense', name: 'Gale Brace', family: 'Air', variant: 'Defense', baseBand: 5, baseDamage: 4, mitigationMultiplier: 0.65, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.0, potency: 0.95, uptime: 1.0, reliability: 1.0, mobility: 1.20, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 0.88 }, description: '65% mitigation', duration: 1800 },
+  { id: 'air_control', name: 'Gale Gust', family: 'Air', variant: 'Control', baseBand: 11, baseDamage: 5, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.10, potency: 0.90, uptime: 1.0, reliability: 1.0, mobility: 1.15, ccCap: 0.95, reaction: 1.15, cooldown: 1.0, risk: 0.95 }, description: '1.0s Knockback', ccDuration: 1.0, ccType: 'Knockback' },
+  { id: 'air_safe_attack', name: 'Breezelash', family: 'Air', variant: 'Attack', baseBand: 3, baseDamage: 6, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.0, potency: 0.85, uptime: 1.0, reliability: 1.0, mobility: 1.25, ccCap: 1.0, reaction: 1.05, cooldown: 1.0, risk: 0.80 }, description: 'Mobile poke' },
+  { id: 'air_agg_attack', name: 'Stormrend', family: 'Air', variant: 'Attack', baseBand: 7, baseDamage: 15, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.20, potency: 1.25, uptime: 1.0, reliability: 0.95, mobility: 1.30, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 1.05 }, description: 'Rapid strikes' },
+  { id: 'spark_attack', name: 'Sparkpop', family: 'Spark', variant: 'Attack', baseBand: 5, baseDamage: 9, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.10, potency: 1.05, uptime: 1.0, reliability: 0.97, mobility: 1.05, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: 'Electric burst' },
+  { id: 'spark_defense', name: 'Spark Net', family: 'Spark', variant: 'Defense', baseBand: 6, baseDamage: 5, mitigationMultiplier: 0.60, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.0, potency: 1.0, uptime: 1.0, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.90 }, description: '60% mitigation', duration: 2000 },
+  { id: 'spark_control', name: 'Thunder-Clap', family: 'Spark', variant: 'Control', baseBand: 12, baseDamage: 6, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.15, potency: 1.0, uptime: 1.0, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.25, cooldown: 1.0, risk: 1.0 }, description: '1.25s Stun', ccDuration: 1.25, ccType: 'Stun' },
+  { id: 'spark_safe_attack', name: 'Coilsnip', family: 'Spark', variant: 'Attack', baseBand: 3, baseDamage: 7, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.05, potency: 0.90, uptime: 1.0, reliability: 0.98, mobility: 1.10, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.85 }, description: 'Quick zap' },
+  { id: 'spark_agg_attack', name: 'Arcburst', family: 'Spark', variant: 'Attack', baseBand: 8, baseDamage: 16, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.25, potency: 1.20, uptime: 1.0, reliability: 0.95, mobility: 1.05, ccCap: 1.0, reaction: 1.30, cooldown: 1.0, risk: 1.05 }, description: 'Chain lightning' },
+  { id: 'spark_heavy_defense', name: 'Arc Ward', family: 'Spark', variant: 'Defense', baseBand: 8, baseDamage: 6, mitigationMultiplier: 0.45, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.0, potency: 1.05, uptime: 1.15, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.25, cooldown: 1.0, risk: 0.85 }, description: '55% mitigation', duration: 2500 },
+  { id: 'verdant_attack', name: 'Verdant Strike', family: 'Verdant', variant: 'Attack', baseBand: 5, baseDamage: 8, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.0, potency: 1.0, uptime: 1.25, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 1.0 }, description: 'Nature strike' },
+  { id: 'verdant_defense', name: 'Verdant Barrier', family: 'Verdant', variant: 'Defense', baseBand: 5, baseDamage: 3, mitigationMultiplier: 0.55, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.0, potency: 0.90, uptime: 1.30, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 0.90 }, description: '55% mitigation', duration: 2200 },
+  { id: 'verdant_control', name: 'Verdant Vines', family: 'Verdant', variant: 'Control', baseBand: 13, baseDamage: 5, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.05, potency: 0.95, uptime: 1.20, reliability: 1.0, mobility: 0.95, ccCap: 1.05, reaction: 1.15, cooldown: 1.0, risk: 1.0 }, description: '1.5s Entangle', ccDuration: 1.5, ccType: 'Entangle' },
+  { id: 'verdant_safe_attack', name: 'Echo Pierce', family: 'Verdant', variant: 'Attack', baseBand: 3, baseDamage: 6, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.0, potency: 0.85, uptime: 1.35, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 0.85 }, description: 'Lingering HoT' },
+  { id: 'verdant_agg_attack', name: 'Wildspin', family: 'Verdant', variant: 'Attack', baseBand: 8, baseDamage: 14, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.20, potency: 1.15, uptime: 1.30, reliability: 1.0, mobility: 1.05, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 1.05 }, description: 'Whirling growth' },
+  { id: 'verdant_heavy_defense', name: 'Verdant Rootwall', family: 'Verdant', variant: 'Defense', baseBand: 7, baseDamage: 4, mitigationMultiplier: 0.35, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.0, potency: 0.85, uptime: 1.50, reliability: 1.0, mobility: 0.75, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.75 }, description: '65% mitigation', duration: 3800 },
+  { id: 'essence_attack', name: 'Aether Dash', family: 'Essence', variant: 'Attack', baseBand: 6, baseDamage: 10, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.0, potency: 1.15, uptime: 1.0, reliability: 1.0, mobility: 1.10, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 1.0 }, description: 'Phase strike' },
+  { id: 'essence_defense', name: 'Essence Shield', family: 'Essence', variant: 'Defense', baseBand: 6, baseDamage: 4, mitigationMultiplier: 0.60, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.0, potency: 1.0, uptime: 1.15, reliability: 1.0, mobility: 1.05, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 0.92 }, description: '60% mitigation', duration: 2100 },
+  { id: 'essence_control', name: 'Aether Suspend', family: 'Essence', variant: 'Control', baseBand: 15, baseDamage: 6, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.0, potency: 1.05, uptime: 1.10, reliability: 1.0, mobility: 1.05, ccCap: 1.15, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: '2.0s Suspend', ccDuration: 2.0, ccType: 'Suspend' },
+  { id: 'essence_safe_attack', name: 'Prism Touch', family: 'Essence', variant: 'Attack', baseBand: 4, baseDamage: 8, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.0, potency: 1.00, uptime: 1.0, reliability: 1.0, mobility: 1.15, ccCap: 1.0, reaction: 1.10, cooldown: 1.0, risk: 0.90 }, description: 'Phase tap' },
+  { id: 'essence_agg_attack', name: 'Essence Fission', family: 'Essence', variant: 'Attack', baseBand: 10, baseDamage: 20, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.15, potency: 1.35, uptime: 1.0, reliability: 1.0, mobility: 1.10, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 1.10 }, description: 'Reality tear' },
+  { id: 'essence_heavy_defense', name: 'Stasis Tower', family: 'Essence', variant: 'Defense', baseBand: 9, baseDamage: 5, mitigationMultiplier: 0.40, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.0, potency: 1.10, uptime: 1.25, reliability: 1.0, mobility: 0.85, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.80 }, description: '60% mitigation', duration: 3000 },
+  { id: 'water_special', name: 'Torrent Cascade', family: 'Water', variant: 'Special', baseBand: 25, baseDamage: 35, governingAttr: 'SPR', governingElem: 'Water', scalars: { scope: 1.20, potency: 1.30, uptime: 1.15, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: 'Wave burst (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'stone_special', name: 'Earthshatter', family: 'Stone', variant: 'Special', baseBand: 30, baseDamage: 50, governingAttr: 'STR', governingElem: 'Stone', scalars: { scope: 1.30, potency: 1.45, uptime: 1.0, reliability: 1.0, mobility: 0.85, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.10 }, description: 'Massive AoE (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'air_special', name: 'Cyclone', family: 'Air', variant: 'Special', baseBand: 22, baseDamage: 28, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.25, potency: 1.25, uptime: 1.0, reliability: 1.0, mobility: 1.25, ccCap: 1.0, reaction: 1.15, cooldown: 1.0, risk: 0.95 }, description: 'Mobile vortex (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'spark_special', name: 'Lightning Storm', family: 'Spark', variant: 'Special', baseBand: 26, baseDamage: 38, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.35, potency: 1.30, uptime: 1.0, reliability: 0.98, mobility: 1.05, ccCap: 1.0, reaction: 1.30, cooldown: 1.0, risk: 1.05 }, description: 'Chain AoE (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'verdant_special', name: 'Regrowth Pulse', family: 'Verdant', variant: 'Special', baseBand: 24, baseDamage: 30, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.15, potency: 1.20, uptime: 1.40, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: 'AoE HoT (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'essence_special', name: 'Void Rift', family: 'Essence', variant: 'Special', baseBand: 32, baseDamage: 45, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.20, potency: 1.40, uptime: 1.10, reliability: 1.0, mobility: 1.15, ccCap: 1.0, reaction: 1.25, cooldown: 1.0, risk: 1.05 }, description: 'Reality tear (R≥0.5)', requiresResonance: 0.5 },
+  { id: 'fire_ultimate', name: 'Inferno', family: 'Fire', variant: 'Special', baseBand: 40, baseDamage: 70, governingAttr: 'STR', governingElem: 'Fire', scalars: { scope: 1.50, potency: 1.60, uptime: 1.0, reliability: 1.0, mobility: 0.90, ccCap: 1.0, reaction: 1.25, cooldown: 1.0, risk: 1.15 }, description: 'Massive fire (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'water_ultimate', name: 'Tidal Wave', family: 'Water', variant: 'Special', baseBand: 38, baseDamage: 60, governingAttr: 'SPR', governingElem: 'Water', scalars: { scope: 1.45, potency: 1.50, uptime: 1.20, reliability: 1.0, mobility: 1.0, ccCap: 1.0, reaction: 1.30, cooldown: 1.0, risk: 1.10 }, description: 'Tsunami (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'stone_ultimate', name: 'Meteor Strike', family: 'Stone', variant: 'Special', baseBand: 42, baseDamage: 80, governingAttr: 'STR', governingElem: 'Stone', scalars: { scope: 1.40, potency: 1.70, uptime: 1.0, reliability: 1.0, mobility: 0.80, ccCap: 1.0, reaction: 1.0, cooldown: 1.0, risk: 1.20 }, description: 'Devastating (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'air_ultimate', name: 'Hurricane', family: 'Air', variant: 'Special', baseBand: 35, baseDamage: 55, governingAttr: 'AGI', governingElem: 'Air', scalars: { scope: 1.55, potency: 1.45, uptime: 1.0, reliability: 1.0, mobility: 1.30, ccCap: 1.0, reaction: 1.20, cooldown: 1.0, risk: 1.0 }, description: 'Massive vortex (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'spark_ultimate', name: 'Thunderstorm', family: 'Spark', variant: 'Special', baseBand: 36, baseDamage: 65, governingAttr: 'DEX', governingElem: 'Spark', scalars: { scope: 1.60, potency: 1.55, uptime: 1.0, reliability: 1.0, mobility: 1.10, ccCap: 1.0, reaction: 1.40, cooldown: 1.0, risk: 1.10 }, description: 'Chain storm (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'verdant_ultimate', name: 'World Tree', family: 'Verdant', variant: 'Special', baseBand: 34, baseDamage: 50, governingAttr: 'SPR', governingElem: 'Verdant', scalars: { scope: 1.35, potency: 1.40, uptime: 1.50, reliability: 1.0, mobility: 0.95, ccCap: 1.0, reaction: 1.25, cooldown: 1.0, risk: 1.05 }, description: 'Massive growth (R≥0.7)', requiresResonance: 0.7 },
+  { id: 'essence_ultimate', name: 'Reality Collapse', family: 'Essence', variant: 'Special', baseBand: 45, baseDamage: 75, governingAttr: 'INS', governingElem: 'Essence', scalars: { scope: 1.40, potency: 1.65, uptime: 1.15, reliability: 1.0, mobility: 1.20, ccCap: 1.0, reaction: 1.35, cooldown: 1.0, risk: 1.15 }, description: 'Void collapse (R≥0.7)', requiresResonance: 0.7 }
+];
+
+export const initialCharacter = {
+  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40 },
+  elements: { Fire: 40, Water: 40, Stone: 40, Air: 40, Spark: 40, Verdant: 40, Essence: 40 },
+  weapon: 'Long Swords',
+  currentER: 100,
+  maxER: 100,
+  hp: 1000,
+  maxHp: 1000,
+  activeDefense: null,
+  ccEffects: []
+};
+
+export const initialEnemy = {
+  hp: 500,
+  maxHp: 500,
+  currentER: 100,
+  maxER: 100,
+  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40 },
+  elements: { Fire: 40, Water: 40, Stone: 40, Air: 40, Spark: 40, Verdant: 40, Essence: 40 },
+  weapon: 'Staffs',
+  aiEnabled: false,
+  activeDefense: null,
+  ccEffects: []
+};
+
+export const LANE_STYLES = {
+  Attack: { active: 'bg-blue-900 border-blue-600', hover: 'hover:bg-blue-800' },
+  Defense: { active: 'bg-green-900 border-green-600', hover: 'hover:bg-green-800' },
+  Control: { active: 'bg-purple-900 border-purple-600', hover: 'hover:bg-purple-800' },
+  Special: { active: 'bg-yellow-900 border-yellow-600', hover: 'hover:bg-yellow-800' }
+};

--- a/packages/combat-sandbox/src/index.js
+++ b/packages/combat-sandbox/src/index.js
@@ -1,0 +1,4 @@
+export { CombatSandbox as default, CombatSandbox } from './CombatSandbox.jsx';
+export * from './constants.js';
+export * from './utils.js';
+export * from './reducers.js';

--- a/packages/combat-sandbox/src/reducers.js
+++ b/packages/combat-sandbox/src/reducers.js
@@ -1,0 +1,95 @@
+export function characterReducer(state, action) {
+  switch (action.type) {
+    case 'SET_ATTRIBUTE':
+      return { ...state, attributes: { ...state.attributes, [action.attr]: action.value } };
+    case 'SET_ELEMENT':
+      return { ...state, elements: { ...state.elements, [action.elem]: action.value } };
+    case 'SET_WEAPON':
+      return { ...state, weapon: action.weapon };
+    case 'SPEND_ER':
+      return { ...state, currentER: Math.max(0, state.currentER - action.amount) };
+    case 'GAIN_ER':
+      return { ...state, currentER: Math.min(100, state.currentER + action.amount) };
+    case 'PASSIVE_REGEN':
+      return { ...state, currentER: Math.min(state.maxER, state.currentER + 1) };
+    case 'TAKE_DAMAGE': {
+      const mitigation = state.activeDefense ? state.activeDefense.mitigationMultiplier : 1.0;
+      return {
+        ...state,
+        hp: Math.max(0, state.hp - Math.round(action.amount * mitigation)),
+        currentER: Math.min(100, state.currentER + 1)
+      };
+    }
+    case 'RESET_HP':
+      return { ...state, hp: state.maxHp, activeDefense: null, ccEffects: [] };
+    case 'SET_DEFENSE':
+      return { ...state, activeDefense: action.defense };
+    case 'CLEAR_DEFENSE':
+      return { ...state, activeDefense: null };
+    case 'ADD_CC': {
+      const cappedDuration = Math.min(action.duration, 2.0);
+      return {
+        ...state,
+        ccEffects: [
+          ...state.ccEffects,
+          {
+            type: action.ccType,
+            duration: cappedDuration,
+            applied: Date.now()
+          }
+        ]
+      };
+    }
+    case 'UPDATE_CC':
+      return {
+        ...state,
+        ccEffects: state.ccEffects.filter((cc) => (Date.now() - cc.applied) / 1000 < cc.duration)
+      };
+    default:
+      return state;
+  }
+}
+
+export function enemyReducer(state, action) {
+  switch (action.type) {
+    case 'TAKE_DAMAGE': {
+      const mitigation = state.activeDefense ? state.activeDefense.mitigationMultiplier : 1.0;
+      return { ...state, hp: Math.max(0, state.hp - Math.round(action.amount * mitigation)) };
+    }
+    case 'RESET':
+      return { ...state, hp: state.maxHp, currentER: state.maxER, activeDefense: null, ccEffects: [] };
+    case 'SPEND_ER':
+      return { ...state, currentER: Math.max(0, state.currentER - action.amount) };
+    case 'GAIN_ER':
+      return { ...state, currentER: Math.min(state.maxER, state.currentER + action.amount) };
+    case 'PASSIVE_REGEN':
+      return { ...state, currentER: Math.min(state.maxER, state.currentER + 1) };
+    case 'TOGGLE_AI':
+      return { ...state, aiEnabled: !state.aiEnabled };
+    case 'SET_DEFENSE':
+      return { ...state, activeDefense: action.defense };
+    case 'CLEAR_DEFENSE':
+      return { ...state, activeDefense: null };
+    case 'ADD_CC': {
+      const cappedDuration = Math.min(action.duration, 2.0);
+      return {
+        ...state,
+        ccEffects: [
+          ...state.ccEffects,
+          {
+            type: action.ccType,
+            duration: cappedDuration,
+            applied: Date.now()
+          }
+        ]
+      };
+    }
+    case 'UPDATE_CC':
+      return {
+        ...state,
+        ccEffects: state.ccEffects.filter((cc) => (Date.now() - cc.applied) / 1000 < cc.duration)
+      };
+    default:
+      return state;
+  }
+}

--- a/packages/combat-sandbox/src/utils.js
+++ b/packages/combat-sandbox/src/utils.js
@@ -1,0 +1,143 @@
+import { WEAPONS, COMBAT_STATES } from './constants.js';
+
+export const calculateResonance = (attrValue, elemValue) => (attrValue / 100) * (elemValue / 100);
+
+export const getAttributeTierDiscount = (value) => {
+  if (value >= 90) return 0.15;
+  if (value >= 60) return 0.10;
+  if (value >= 30) return 0.05;
+  return 0;
+};
+
+export const getResonanceDiscount = (resonance) => {
+  if (resonance >= 0.9) return 0.20;
+  if (resonance >= 0.7) return 0.15;
+  if (resonance >= 0.5) return 0.10;
+  if (resonance >= 0.3) return 0.05;
+  return 0;
+};
+
+export const getResonanceTier = (resonance) => {
+  if (resonance >= 0.7) return 'Merged';
+  if (resonance >= 0.5) return 'Bonded';
+  if (resonance >= 0.3) return 'Touched';
+  return 'Base';
+};
+
+export const calculateAnimationTiming = (weapon, agiValue) => {
+  const weaponData = WEAPONS[weapon];
+  const massModifier = 1 + (weaponData.mass - 1) * 0.1;
+  const agiModifier = 1 - (agiValue / 100) * 0.3;
+  const windUpReduction = weaponData.windUpReduction || 0;
+
+  return {
+    windUp: weaponData.windUpBase * massModifier * agiModifier * (1 - windUpReduction),
+    recovery: weaponData.recoveryBase * massModifier * agiModifier
+  };
+};
+
+export const calculateERCost = (ability, character) => {
+  const attrValue = character.attributes[ability.governingAttr] || 0;
+  const elemValue = character.elements[ability.governingElem] || 0;
+  const resonance = calculateResonance(attrValue, elemValue);
+  const s = ability.scalars;
+
+  const grossCost = ability.baseBand * (s.scope || 1) * (s.potency || 1) * (s.uptime || 1) *
+    (s.reliability || 1) * (s.mobility || 1) * (s.ccCap || 1) *
+    (s.reaction || 1) * (s.cooldown || 1) * (s.risk || 1);
+
+  const finalCost = grossCost * (1 - getAttributeTierDiscount(attrValue)) * (1 - getResonanceDiscount(resonance));
+
+  return {
+    grossCost,
+    finalCost: Math.round(finalCost * 10) / 10,
+    resonance,
+    resonanceTier: getResonanceTier(resonance)
+  };
+};
+
+export const calculateDamage = (ability, character) => {
+  const attrValue = character.attributes[ability.governingAttr] || 0;
+  const elemValue = character.elements[ability.governingElem] || 0;
+  const resonance = calculateResonance(attrValue, elemValue);
+  const weaponMult = WEAPONS[character.weapon].damageMultiplier;
+  return Math.round((ability.baseDamage || 10) * (1 + attrValue / 100) * (1 + resonance) * weaponMult);
+};
+
+export const resolveCombatPhase = ({
+  combatState,
+  setCombatState,
+  character,
+  dispatchEnemy,
+  dispatchCharacter,
+  addLog,
+  setPerfectTimingWindow,
+  ccSuccessTimestamps,
+  setCcSuccessTimestamps
+}) => {
+  if (combatState.state === COMBAT_STATES.IDLE) {
+    return;
+  }
+
+  const timing = calculateAnimationTiming(character.weapon, character.attributes.AGI);
+  const phaseDuration = combatState.state === COMBAT_STATES.WIND_UP ? timing.windUp : timing.recovery;
+  const elapsed = (Date.now() - combatState.startTime) / 1000;
+  const progress = Math.min(elapsed / phaseDuration, 1);
+
+  setCombatState((prev) => ({ ...prev, progress }));
+
+  if (progress < 1) {
+    return;
+  }
+
+  if (combatState.state === COMBAT_STATES.WIND_UP) {
+    const ability = combatState.ability;
+    const dmg = calculateDamage(ability, character);
+    dispatchEnemy({ type: 'TAKE_DAMAGE', amount: dmg });
+    addLog(`${ability.name} hits for ${dmg} damage`, 'damage');
+
+    if (ability.variant === 'Attack') {
+      const erGain = WEAPONS[character.weapon].erGainedOnHit || 2;
+      dispatchCharacter({ type: 'GAIN_ER', amount: erGain });
+      addLog(`+${erGain} ER`, 'er');
+    } else if (ability.variant === 'Defense') {
+      dispatchCharacter({ type: 'SET_DEFENSE', defense: ability });
+      const perfectWindow = ability.perfectWindow || 0.3;
+      setPerfectTimingWindow({
+        startTime: Date.now(),
+        duration: perfectWindow * 1000,
+        ability
+      });
+
+      addLog(`Defense active! ${perfectWindow.toFixed(1)}s perfect window`, 'info');
+
+      setTimeout(() => {
+        setPerfectTimingWindow(null);
+        dispatchCharacter({ type: 'CLEAR_DEFENSE' });
+        addLog('Defense ended', 'info');
+      }, ability.duration || 2000);
+    } else if (ability.variant === 'Control') {
+      if (ability.ccDuration && ability.ccType) {
+        const cappedDuration = Math.min(ability.ccDuration, 2.0);
+        dispatchEnemy({ type: 'ADD_CC', ccType: ability.ccType, duration: cappedDuration });
+        addLog(`Applied ${ability.ccType} (${cappedDuration}s, capped at 2.0s)`, 'info');
+
+        const now = Date.now();
+        const lastSuccess = ccSuccessTimestamps[ability.id] || 0;
+        const timeSinceLastSuccess = (now - lastSuccess) / 1000;
+
+        if (timeSinceLastSuccess >= 2.0) {
+          dispatchCharacter({ type: 'GAIN_ER', amount: 1 });
+          addLog('CC success! +1 ER (2s gate passed)', 'er');
+          setCcSuccessTimestamps((prev) => ({ ...prev, [ability.id]: now }));
+        } else {
+          addLog(`CC applied (ER gain on cooldown: ${(2.0 - timeSinceLastSuccess).toFixed(1)}s)`, 'info');
+        }
+      }
+    }
+
+    setCombatState({ state: COMBAT_STATES.RECOVERY, ability, progress: 0, startTime: Date.now() });
+  } else {
+    setCombatState({ state: COMBAT_STATES.IDLE, ability: null, progress: 0, startTime: 0 });
+  }
+};

--- a/packages/combat-sandbox/styles.css
+++ b/packages/combat-sandbox/styles.css
@@ -1,0 +1,166 @@
+/*
+  The sandbox relies on Tailwind-style utility classes from the demo project.
+  Consumers can adapt these rules or replace them with their own framework.
+  This file offers a minimal baseline mirroring the colour palette used in the
+  standalone prototype so the component renders legibly without Tailwind.
+*/
+
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background-color: #111827;
+  color: #f9fafb;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+/* Simple utility approximations */
+.bg-gray-900 { background-color: #111827; }
+.bg-gray-800 { background-color: #1f2937; }
+.bg-gray-700 { background-color: #374151; }
+.bg-gray-600 { background-color: #4b5563; }
+.bg-purple-900 { background-color: #4c1d95; }
+.bg-purple-600 { background-color: #7c3aed; }
+.bg-purple-500 { background-color: #a855f7; }
+.bg-blue-900 { background-color: #1e3a8a; }
+.bg-blue-800 { background-color: #1d4ed8; }
+.bg-blue-500 { background-color: #3b82f6; }
+.bg-green-900 { background-color: #064e3b; }
+.bg-green-800 { background-color: #047857; }
+.bg-green-700 { background-color: #047857; }
+.bg-green-600 { background-color: #16a34a; }
+.bg-yellow-900 { background-color: #78350f; }
+.bg-yellow-800 { background-color: #b45309; }
+.bg-yellow-700 { background-color: #d97706; }
+.bg-yellow-600 { background-color: #f59e0b; }
+.bg-yellow-500 { background-color: #fbbf24; }
+.bg-red-900 { background-color: #7f1d1d; }
+.bg-red-700 { background-color: #b91c1c; }
+.bg-red-600 { background-color: #dc2626; }
+.bg-red-500 { background-color: #ef4444; }
+.bg-cyan-900 { background-color: #155e75; }
+.bg-cyan-500 { background-color: #06b6d4; }
+.bg-blue-500 { background-color: #3b82f6; }
+.bg-orange-900 { background-color: #7c2d12; }
+.bg-gray-500 { background-color: #6b7280; }
+
+.border-purple-600 { border-color: #7c3aed; }
+.border-blue-600 { border-color: #2563eb; }
+.border-green-600 { border-color: #16a34a; }
+.border-yellow-600 { border-color: #d97706; }
+.border-gray-700 { border-color: #374151; }
+
+.text-white { color: #f9fafb; }
+.text-gray-500 { color: #6b7280; }
+.text-gray-400 { color: #9ca3af; }
+.text-gray-300 { color: #d1d5db; }
+.text-cyan-400 { color: #22d3ee; }
+.text-red-400 { color: #f87171; }
+.text-green-400 { color: #4ade80; }
+.text-purple-400 { color: #c084fc; }
+.text-yellow-400 { color: #facc15; }
+.text-blue-400 { color: #60a5fa; }
+.text-orange-400 { color: #fb923c; }
+
+.rounded { border-radius: 0.5rem; }
+.rounded-lg { border-radius: 0.75rem; }
+.rounded-full { border-radius: 9999px; }
+
+.border-2 { border-width: 2px; border-style: solid; }
+
+.p-4 { padding: 1rem; }
+.p-3 { padding: 0.75rem; }
+.p-2 { padding: 0.5rem; }
+.p-2\.5 { padding: 0.625rem; }
+.p-1\.5 { padding: 0.375rem; }
+
+.py-1\.5 { padding-top: 0.375rem; padding-bottom: 0.375rem; }
+.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-1\.5 { padding-left: 0.375rem; padding-right: 0.375rem; }
+
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
+.mt-1\.5 { margin-top: 0.375rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+
+.text-xs { font-size: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-base { font-size: 1rem; }
+.text-lg { font-size: 1.125rem; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-4xl { font-size: 2.25rem; }
+
+.font-bold { font-weight: 700; }
+.font-semibold { font-weight: 600; }
+.font-mono { font-family: 'Fira Mono', 'SFMono-Regular', ui-monospace, 'Menlo', monospace; }
+
+.grid { display: grid; }
+.grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.gap-4 { gap: 1rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-2 { gap: 0.5rem; }
+
+.col-span-3 { grid-column: span 3 / span 3; }
+.col-span-6 { grid-column: span 6 / span 6; }
+
+.min-h-screen { min-height: 100vh; }
+.h-64 { height: 16rem; }
+.h-2\.5 { height: 0.625rem; }
+.h-2 { height: 0.5rem; }
+.h-1\.5 { height: 0.375rem; }
+.h-16 { height: 4rem; }
+
+.w-full { width: 100%; }
+.w-16 { width: 4rem; }
+
+.flex { display: flex; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.justify-center { justify-content: center; }
+
+.space-y-1 > * + * { margin-top: 0.25rem; }
+.space-y-1\.5 > * + * { margin-top: 0.375rem; }
+.space-y-2 > * + * { margin-top: 0.5rem; }
+
+.max-h-96 { max-height: 24rem; }
+.overflow-y-auto { overflow-y: auto; }
+
+.text-center { text-align: center; }
+.relative { position: relative; }
+.absolute { position: absolute; }
+.left-0 { left: 0; }
+.right-0 { right: 0; }
+.top-1 { top: 0.25rem; }
+.-bottom-2 { bottom: -0.5rem; }
+
+.animate-pulse {
+  animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure the reducers, component state updates, and utilities use spread syntax when cloning state
- retain the ER cost rounding logic in the shared utilities module
- export the package CSS entry point and mark it as a side effect so bundlers can import it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff8e715c832a80ea35cff5374583