### PR TITLE
Add Vite host for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Vite prints a local URL (typically <http://localhost:5173>) – open it in a bro
 
 > **Tip:** If you want to iterate on the component itself, keep the host running and edit the files under `packages/combat-sandbox/`. Vite will hot reload the changes.
 
+## Publish the sandbox to GitHub Pages
+
+The repository now includes a ready-to-ship Vite host under `pages/combat-sandbox-pages/`. It links to the local package via a `file:` dependency, applies the correct base path for project Pages deployments, and emits its production build to `docs/demo/` so that GitHub Pages can pick it up.
+
+```bash
+cd pages/combat-sandbox-pages
+npm install
+npm run build
+```
+
+Commit the generated `docs/demo/` contents and configure the repository to publish from the **docs/** folder. The hosted sandbox will be served from `https://<your-user>.github.io/WWComSan/demo/` alongside the existing Markdown documentation.
+
 ## Playing the sandbox
 
 * **Build Lab (left column):** adjust quick resonance presets, pick one of the 23 weapon types, and tweak every attribute/element slider to explore how resonance values shift. The live resonance panel surfaces thresholds for Bonded and Merged abilities so you know when higher tier skills unlock.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Worlds Within Combat Sandbox
 
-This GitHub Pages site renders the Markdown documentation for the combat sandbox package. The playable demo itself is delivered as a React component, so the published site is informational rather than a standalone HTML build of the experience.
+This GitHub Pages site renders the Markdown documentation for the combat sandbox package. The playable demo itself is delivered as a React component and is now bundled through the Vite host that lives under `docs/demo/`.
 
 ## What ships on Pages?
 
@@ -36,4 +36,4 @@ The repository exports the `@tba-worldswithin/combat-sandbox` package. Consumers
 
 ## Need a hosted build?
 
-To give non-developers a one-click playtest environment, deploy a small host app (for example the Vite setup above) and publish its production build to Pages. That build will produce the necessary `index.html` and asset files, while this repository continues to track documentation as Markdown.
+A preconfigured Vite host lives at [`pages/combat-sandbox-pages/`](../pages/combat-sandbox-pages/README.md). Running `npm run build` from that directory emits its production bundle to `docs/demo/` so GitHub Pages can serve the interactive sandbox alongside these docs. Point interested playtesters to `https://<your-user>.github.io/WWComSan/demo/` after publishing.

--- a/pages/combat-sandbox-pages/README.md
+++ b/pages/combat-sandbox-pages/README.md
@@ -1,0 +1,25 @@
+# Combat Sandbox Pages Host
+
+This directory contains a small Vite application that embeds the `@tba-worldswithin/combat-sandbox` package so it can be published to GitHub Pages.
+
+## Available scripts
+
+From this folder run:
+
+```bash
+npm install
+npm run dev
+npm run build
+```
+
+* `npm run dev` – starts a local dev server for iterating on the host shell.
+* `npm run build` – outputs a static production build under `docs/demo` at the repository root. Point GitHub Pages at the `/docs` directory to publish the demo.
+
+Because the sandbox is linked via a relative `file:` dependency, changes under `packages/combat-sandbox/` are picked up automatically during development.
+
+## Deploying to Pages
+
+1. Run `npm run build` from this folder.
+2. Commit the generated contents of `docs/demo`.
+3. In the repository settings enable GitHub Pages with the **docs/** folder as the source.
+4. Visit `https://<your-user>.github.io/WWComSan/demo/` to interact with the hosted sandbox.

--- a/pages/combat-sandbox-pages/index.html
+++ b/pages/combat-sandbox-pages/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Worlds Within Combat Sandbox</title>
+    <meta
+      name="description"
+      content="Interactive Worlds Within combat sandbox hosted for GitHub Pages"
+    />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/pages/combat-sandbox-pages/package.json
+++ b/pages/combat-sandbox-pages/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "combat-sandbox-pages",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tba-worldswithin/combat-sandbox": "file:../../packages/combat-sandbox",
+    "lucide-react": "^0.360.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/pages/combat-sandbox-pages/public/favicon.svg
+++ b/pages/combat-sandbox-pages/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#g)" />
+  <path
+    d="M34 34h20l10 18 10-18h20l-30 60z"
+    fill="#0f172a"
+    stroke="#e2e8f0"
+    stroke-width="6"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/pages/combat-sandbox-pages/src/App.jsx
+++ b/pages/combat-sandbox-pages/src/App.jsx
@@ -1,0 +1,32 @@
+import CombatSandbox from '@tba-worldswithin/combat-sandbox';
+import '@tba-worldswithin/combat-sandbox/styles.css';
+import './app.css';
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Worlds Within Combat Sandbox</h1>
+        <p>
+          This host bundles the reusable combat sandbox package so it can be published as a GitHub Pages demo.
+          The build emitted by Vite lives under <code>docs/demo</code> and can be served from the repository&apos;s Pages configuration.
+        </p>
+        <p className="app-links">
+          <a href="../" rel="noreferrer">
+            Documentation
+          </a>
+          <span aria-hidden="true">•</span>
+          <a href="https://github.com/tba-worldswithin/WWComSan" target="_blank" rel="noreferrer">
+            GitHub Repository
+          </a>
+        </p>
+      </header>
+      <main className="sandbox-wrapper">
+        <CombatSandbox />
+      </main>
+      <footer className="app-footer">
+        <p>MIT © 2024 Worlds Within Prototype</p>
+      </footer>
+    </div>
+  );
+}

--- a/pages/combat-sandbox-pages/src/app.css
+++ b/pages/combat-sandbox-pages/src/app.css
@@ -1,0 +1,74 @@
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, #1e293b 0%, #0f172a 55%, #020617 100%);
+  color: #e2e8f0;
+}
+
+.app-header {
+  padding: 2.5rem 1.5rem 1.5rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+}
+
+.app-header p {
+  max-width: 720px;
+  margin: 0.5rem auto;
+  line-height: 1.6;
+}
+
+.app-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.app-links a {
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+.app-links a:hover,
+.app-links a:focus {
+  text-decoration: underline;
+}
+
+.sandbox-wrapper {
+  flex: 1 1 auto;
+  padding: 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.sandbox-wrapper > * {
+  width: 100%;
+  max-width: 1440px;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.75);
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.app-footer {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #94a3b8;
+}
+
+@media (max-width: 768px) {
+  .sandbox-wrapper {
+    padding: 1rem 0.5rem 2rem;
+  }
+
+  .sandbox-wrapper > * {
+    border-radius: 0;
+  }
+}

--- a/pages/combat-sandbox-pages/src/index.css
+++ b/pages/combat-sandbox-pages/src/index.css
@@ -1,0 +1,24 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #f8fafc;
+  background-color: #020617;
+}
+
+body {
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus {
+  outline: 2px solid #38bdf8;
+  outline-offset: 4px;
+}

--- a/pages/combat-sandbox-pages/src/main.jsx
+++ b/pages/combat-sandbox-pages/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/pages/combat-sandbox-pages/vite.config.js
+++ b/pages/combat-sandbox-pages/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+const repoBase = process.env.VITE_PAGES_BASE || '/WWComSan/demo/';
+
+export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : repoBase,
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  build: {
+    outDir: '../../docs/demo',
+    emptyOutDir: true
+  }
+}));


### PR DESCRIPTION
## Summary
- add a Vite-powered host in `pages/combat-sandbox-pages` that links to the local combat sandbox package and outputs its build to `docs/demo`
- style the host shell and surface documentation links so the sandbox can be served from GitHub Pages alongside the existing docs
- update repository docs with publishing instructions for the new Pages-ready build

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3119bff74832a8d983461150217d6