### PR TITLE
Add combat sandbox test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+      - run: npm run test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wwcomsan",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "packages/*",
+    "pages/*"
+  ],
+  "scripts": {
+    "test": "npm run test --workspace @tba-worldswithin/combat-sandbox"
+  }
+}

--- a/packages/combat-sandbox/package.json
+++ b/packages/combat-sandbox/package.json
@@ -12,11 +12,24 @@
     "./package.json": "./package.json"
   },
   "sideEffects": ["./styles.css"],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17"
   },
   "dependencies": {
     "lucide-react": "^0.360.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/user-event": "^14.5.1",
+    "jsdom": "^24.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/packages/combat-sandbox/src/__tests__/CombatSandbox.test.jsx
+++ b/packages/combat-sandbox/src/__tests__/CombatSandbox.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import CombatSandbox from '../CombatSandbox.jsx';
+import { initialCharacter, initialEnemy } from '../constants.js';
+
+vi.mock('lucide-react', () => ({
+  Swords: () => <span data-icon="swords" />,
+  Target: () => <span data-icon="target" />,
+  Activity: () => <span data-icon="activity" />,
+  Settings: () => <span data-icon="settings" />
+}));
+
+describe('CombatSandbox component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('resolves an attack cast and records combat log entries', async () => {
+    const user = userEvent.setup({ delay: null });
+
+    const characterState = {
+      ...initialCharacter,
+      attributes: { ...initialCharacter.attributes },
+      elements: { ...initialCharacter.elements }
+    };
+
+    render(
+      <CombatSandbox
+        initialCharacterState={characterState}
+        initialEnemyState={initialEnemy}
+        abilityLoadout={{ attack: 'verdant_safe_attack', defense: 'fire_defense', control: 'fire_control', special: 'fire_special' }}
+      />
+    );
+
+    const attackButton = await screen.findByRole('button', { name: /Echo Pierce/i });
+
+    await user.click(attackButton);
+
+    expect(await screen.findByText('Casting Echo Pierce (-3.1 ER)')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText('Echo Pierce heals for 133 HP')).toBeInTheDocument();
+    expect(await screen.findByText('Echo Pierce hits for 11 damage')).toBeInTheDocument();
+    expect(await screen.findByText('+4 ER')).toBeInTheDocument();
+  });
+});

--- a/packages/combat-sandbox/src/__tests__/reducers.test.js
+++ b/packages/combat-sandbox/src/__tests__/reducers.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { characterReducer, enemyReducer } from '../reducers.js';
+
+const baseCharacterState = {
+  hp: 200,
+  maxHp: 200,
+  currentER: 50,
+  maxER: 100,
+  attributes: { STR: 20, DEX: 20, INS: 20, SPR: 20, CHA: 20, TOU: 50, AGI: 20 },
+  elements: { Fire: 20, Water: 20 },
+  weapon: 'Long Swords',
+  activeDefense: null,
+  ccEffects: []
+};
+
+describe('characterReducer', () => {
+  it('grants ER on dodge without applying damage', () => {
+    const dodged = characterReducer(baseCharacterState, {
+      type: 'TAKE_DAMAGE',
+      amount: 100,
+      didDodge: true,
+      dodgeErGain: 5,
+      dodgeTimestamp: 1234
+    });
+
+    expect(dodged.hp).toBe(baseCharacterState.hp);
+    expect(dodged.currentER).toBe(baseCharacterState.currentER + 5);
+    expect(dodged.lastDodge).toBe(1234);
+  });
+
+  it('applies mitigation, toughness reduction, and ER gain on hit', () => {
+    const mitigatedState = characterReducer(
+      { ...baseCharacterState, activeDefense: { mitigationMultiplier: 0.5 }, currentER: 98 },
+      { type: 'TAKE_DAMAGE', amount: 100, erOnHit: 3 }
+    );
+
+    expect(mitigatedState.hp).toBe(155);
+    expect(mitigatedState.currentER).toBe(100);
+  });
+
+  it('caps CC durations and stores computed expiration', () => {
+    const ccState = characterReducer(baseCharacterState, {
+      type: 'ADD_CC',
+      ccType: 'Stun',
+      duration: 3,
+      applied: 1000
+    });
+
+    expect(ccState.ccEffects).toHaveLength(1);
+    expect(ccState.ccEffects[0]).toMatchObject({
+      type: 'Stun',
+      duration: 2,
+      applied: 1000,
+      expiresAt: 3000
+    });
+  });
+
+  it('removes expired CC entries based on provided timestamp', () => {
+    const stateWithCc = {
+      ...baseCharacterState,
+      ccEffects: [
+        { type: 'Stun', duration: 2, applied: 0, expiresAt: 1000 },
+        { type: 'Slow', duration: 1.5, applied: 0, expiresAt: 4000 }
+      ]
+    };
+
+    const updated = characterReducer(stateWithCc, { type: 'UPDATE_CC', currentTime: 2500 });
+
+    expect(updated.ccEffects).toEqual([
+      { type: 'Slow', duration: 1.5, applied: 0, expiresAt: 4000 }
+    ]);
+  });
+
+  it('regenerates ER passively without exceeding maxER', () => {
+    const regen = characterReducer({ ...baseCharacterState, currentER: 99, maxER: 100 }, { type: 'PASSIVE_REGEN' });
+    expect(regen.currentER).toBe(100);
+  });
+});
+
+const baseEnemyState = {
+  hp: 300,
+  maxHp: 300,
+  currentER: 95,
+  maxER: 100,
+  activeDefense: { mitigationMultiplier: 0.6 },
+  ccEffects: []
+};
+
+describe('enemyReducer', () => {
+  it('applies mitigation when taking damage', () => {
+    const result = enemyReducer(baseEnemyState, { type: 'TAKE_DAMAGE', amount: 100 });
+    expect(result.hp).toBe(240);
+  });
+
+  it('adds CC effects through helper payload', () => {
+    const result = enemyReducer(baseEnemyState, {
+      type: 'ADD_CC',
+      ccType: 'Root',
+      duration: 2.5,
+      applied: 2000
+    });
+
+    expect(result.ccEffects).toHaveLength(1);
+    expect(result.ccEffects[0].duration).toBe(2);
+    expect(result.ccEffects[0].expiresAt).toBe(4000);
+  });
+
+  it('filters expired CC effects and regenerates ER', () => {
+    const stateWithCc = {
+      ...baseEnemyState,
+      ccEffects: [
+        { type: 'Root', duration: 2, applied: 0, expiresAt: 1500 },
+        { type: 'Shock', duration: 2, applied: 0, expiresAt: 5000 }
+      ],
+      currentER: 99
+    };
+
+    const afterUpdate = enemyReducer(stateWithCc, { type: 'UPDATE_CC', currentTime: 2000 });
+    expect(afterUpdate.ccEffects).toEqual([
+      { type: 'Shock', duration: 2, applied: 0, expiresAt: 5000 }
+    ]);
+
+    const afterRegen = enemyReducer(afterUpdate, { type: 'PASSIVE_REGEN' });
+    expect(afterRegen.currentER).toBe(100);
+  });
+});

--- a/packages/combat-sandbox/src/__tests__/setup.js
+++ b/packages/combat-sandbox/src/__tests__/setup.js
@@ -1,0 +1,13 @@
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+const raf = (cb) => setTimeout(() => cb(Date.now()), 16);
+
+beforeAll(() => {
+  vi.stubGlobal('requestAnimationFrame', raf);
+  vi.stubGlobal('cancelAnimationFrame', (id) => clearTimeout(id));
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});

--- a/packages/combat-sandbox/src/__tests__/utils.test.js
+++ b/packages/combat-sandbox/src/__tests__/utils.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { calculateDamage, calculateERCost, calculateHealing } from '../utils.js';
+
+const baseCharacter = {
+  weapon: 'Long Swords',
+  attributes: {
+    STR: 80,
+    DEX: 40,
+    INS: 30,
+    SPR: 80,
+    CHA: 50,
+    TOU: 0,
+    AGI: 0
+  },
+  elements: {
+    Fire: 90,
+    Verdant: 70
+  }
+};
+
+describe('calculateERCost', () => {
+  it('applies attribute and resonance discounts with rounding and tier detection', () => {
+    const ability = {
+      baseBand: 10,
+      governingAttr: 'STR',
+      governingElem: 'Fire',
+      scalars: {
+        scope: 1,
+        potency: 1,
+        uptime: 1,
+        reliability: 1,
+        mobility: 1,
+        ccCap: 1,
+        reaction: 1,
+        cooldown: 1,
+        risk: 1
+      }
+    };
+
+    const character = {
+      ...baseCharacter,
+      attributes: { ...baseCharacter.attributes, STR: 60 },
+      elements: { ...baseCharacter.elements, Fire: 70 }
+    };
+
+    const result = calculateERCost(ability, character);
+
+    expect(result.grossCost).toBe(10);
+    expect(result.finalCost).toBe(8.6);
+    expect(result.resonance).toBeCloseTo(0.42, 5);
+    expect(result.resonanceTier).toBe('Touched');
+  });
+});
+
+describe('calculateDamage', () => {
+  it('scales with resonance tiers, weapon multiplier, and composite attribute weights', () => {
+    const ability = {
+      variant: 'Attack',
+      baseDamage: 100,
+      governingAttr: 'STR',
+      governingElem: 'Fire'
+    };
+
+    const character = {
+      ...baseCharacter,
+      weapon: 'Long Swords',
+      attributes: { ...baseCharacter.attributes, STR: 80 },
+      elements: { ...baseCharacter.elements, Fire: 90 }
+    };
+
+    const damage = calculateDamage(ability, character);
+
+    expect(damage).toBe(381);
+  });
+});
+
+describe('calculateHealing', () => {
+  it('includes resonance bonus and rounded totals for supportive stats', () => {
+    const ability = {
+      baseHealing: 200,
+      governingAttr: 'SPR',
+      governingElem: 'Verdant'
+    };
+
+    const character = {
+      ...baseCharacter,
+      attributes: { ...baseCharacter.attributes, SPR: 80, CHA: 50 },
+      elements: { ...baseCharacter.elements, Verdant: 70 }
+    };
+
+    const healing = calculateHealing(ability, character);
+
+    expect(healing).toBe(554);
+  });
+});

--- a/packages/combat-sandbox/vitest.config.js
+++ b/packages/combat-sandbox/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.js']
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest for the combat sandbox workspace and add testing dependencies
- add unit tests for utility math, reducers, and a React Testing Library flow that drives CombatSandbox
- add a root workspace manifest and CI workflow that runs the sandbox tests

## Testing
- npm run test *(fails: vitest binary unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e32ce4c730832a9f24b0b2fcfda5ff