### PR TITLE
Add Impact attribute to combat sandbox

### DIFF
--- a/packages/combat-sandbox/src/CombatSandbox.jsx
+++ b/packages/combat-sandbox/src/CombatSandbox.jsx
@@ -3,6 +3,7 @@ import { Swords, Target, Activity, Settings } from 'lucide-react';
 import {
   ABILITIES,
   ATTRIBUTES,
+  ATTRIBUTE_DESCRIPTIONS,
   COMBAT_STATES,
   ELEMENTS,
   LANE_STYLES,
@@ -512,6 +513,11 @@ export function CombatSandbox({
                 onChange={(e) => dispatchCharacter({ type: 'SET_ATTRIBUTE', attr, value: parseInt(e.target.value, 10) })}
                 className="w-full h-2 rounded"
               />
+              {ATTRIBUTE_DESCRIPTIONS[attr] ? (
+                <p className="mt-1 text-[10px] leading-tight text-gray-400">
+                  {ATTRIBUTE_DESCRIPTIONS[attr]}
+                </p>
+              ) : null}
             </div>
           ))}
 

--- a/packages/combat-sandbox/src/__tests__/CombatSandbox.test.jsx
+++ b/packages/combat-sandbox/src/__tests__/CombatSandbox.test.jsx
@@ -52,7 +52,7 @@ describe('CombatSandbox component', () => {
     });
 
     expect(await screen.findByText('Echo Pierce heals for 133 HP')).toBeInTheDocument();
-    expect(await screen.findByText('Echo Pierce hits for 11 damage')).toBeInTheDocument();
+    expect(await screen.findByText('Echo Pierce hits for 12 damage')).toBeInTheDocument();
     expect(await screen.findByText('+4 ER')).toBeInTheDocument();
   });
 });

--- a/packages/combat-sandbox/src/__tests__/reducers.test.js
+++ b/packages/combat-sandbox/src/__tests__/reducers.test.js
@@ -6,7 +6,7 @@ const baseCharacterState = {
   maxHp: 200,
   currentER: 50,
   maxER: 100,
-  attributes: { STR: 20, DEX: 20, INS: 20, SPR: 20, CHA: 20, TOU: 50, AGI: 20 },
+  attributes: { STR: 20, DEX: 20, INS: 20, SPR: 20, CHA: 20, TOU: 50, AGI: 20, Impact: 15 },
   elements: { Fire: 20, Water: 20 },
   weapon: 'Long Swords',
   activeDefense: null,

--- a/packages/combat-sandbox/src/__tests__/utils.test.js
+++ b/packages/combat-sandbox/src/__tests__/utils.test.js
@@ -10,7 +10,8 @@ const baseCharacter = {
     SPR: 80,
     CHA: 50,
     TOU: 0,
-    AGI: 0
+    AGI: 0,
+    Impact: 40
   },
   elements: {
     Fire: 90,
@@ -70,7 +71,7 @@ describe('calculateDamage', () => {
 
     const damage = calculateDamage(ability, character);
 
-    expect(damage).toBe(381);
+    expect(damage).toBe(412);
   });
 });
 

--- a/packages/combat-sandbox/src/constants.js
+++ b/packages/combat-sandbox/src/constants.js
@@ -1,4 +1,4 @@
-export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA'];
+export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA', 'Impact'];
 
 export const ELEMENTS = ['Fire', 'Water', 'Stone', 'Air', 'Spark', 'Verdant', 'Essence'];
 
@@ -156,7 +156,7 @@ export const ABILITIES = [
 ];
 
 export const initialCharacter = {
-  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40 },
+  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40, Impact: 40 },
   elements: { Fire: 40, Water: 40, Stone: 40, Air: 40, Spark: 40, Verdant: 40, Essence: 40 },
   weapon: 'Long Swords',
   currentER: 100,
@@ -172,7 +172,7 @@ export const initialEnemy = {
   maxHp: 500,
   currentER: 100,
   maxER: 100,
-  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40 },
+  attributes: { STR: 40, DEX: 40, TOU: 40, AGI: 40, SPR: 40, INS: 40, CHA: 40, Impact: 40 },
   elements: { Fire: 40, Water: 40, Stone: 40, Air: 40, Spark: 40, Verdant: 40, Essence: 40 },
   weapon: 'Staffs',
   aiEnabled: false,

--- a/packages/combat-sandbox/src/constants.js
+++ b/packages/combat-sandbox/src/constants.js
@@ -1,5 +1,9 @@
 export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA', 'Impact'];
 
+export const ATTRIBUTE_DESCRIPTIONS = {
+  Impact: 'Boosts the payoff of damage abilities by amplifying the final damage multiplier for Attacks and Specials.'
+};
+
 export const ELEMENTS = ['Fire', 'Water', 'Stone', 'Air', 'Spark', 'Verdant', 'Essence'];
 
 export const WEAPONS = {

--- a/packages/combat-sandbox/src/utils.js
+++ b/packages/combat-sandbox/src/utils.js
@@ -84,12 +84,13 @@ export const calculateDamage = (ability, character) => {
   const strMod = 1 + ((character.attributes.STR || 0) / 100) * 0.5;
   const dexMod = 1 + ((character.attributes.DEX || 0) / 100) * 0.3;
   const insMod = 1 + ((character.attributes.INS || 0) / 100) * 0.4;
+  const impactMod = 1 + ((character.attributes.Impact || 0) / 100) * 0.2;
 
   let finalMod = 1 + attrValue / 100;
   if (ability.variant === 'Attack') {
-    finalMod *= (strMod * 0.4 + dexMod * 0.3 + insMod * 0.3);
+    finalMod *= (strMod * 0.4 + dexMod * 0.3 + insMod * 0.3) * impactMod;
   } else if (ability.variant === 'Special') {
-    finalMod *= (insMod * 0.5 + strMod * 0.3 + dexMod * 0.2);
+    finalMod *= (insMod * 0.5 + strMod * 0.3 + dexMod * 0.2) * (1 + ((character.attributes.Impact || 0) / 100) * 0.1);
   }
 
   const baseDamage = ability.baseDamage ?? 10;


### PR DESCRIPTION
## Summary
- add the Impact attribute to sandbox defaults so it appears in the attribute controls
- fold the new Impact stat into damage calculations and align the accompanying unit tests

## Testing
- npm run test --workspace @tba-worldswithin/combat-sandbox *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e32dece4c0832aad53239bf101f70e