### PR TITLE
Use maxER when gaining ER for characters

### DIFF
--- a/packages/combat-sandbox/src/__tests__/reducers.test.js
+++ b/packages/combat-sandbox/src/__tests__/reducers.test.js
@@ -38,6 +38,26 @@ describe('characterReducer', () => {
     expect(mitigatedState.currentER).toBe(100);
   });
 
+  it('respects character maxER when gaining ER directly', () => {
+    const state = { ...baseCharacterState, currentER: 145, maxER: 150 };
+    const gained = characterReducer(state, { type: 'GAIN_ER', amount: 10 });
+
+    expect(gained.currentER).toBe(150);
+  });
+
+  it('respects character maxER when gaining ER from a dodge', () => {
+    const state = { ...baseCharacterState, currentER: 155, maxER: 160 };
+    const dodged = characterReducer(state, {
+      type: 'TAKE_DAMAGE',
+      amount: 999,
+      didDodge: true,
+      dodgeErGain: 10
+    });
+
+    expect(dodged.hp).toBe(state.hp);
+    expect(dodged.currentER).toBe(160);
+  });
+
   it('caps CC durations and stores computed expiration', () => {
     const ccState = characterReducer(baseCharacterState, {
       type: 'ADD_CC',

--- a/packages/combat-sandbox/src/reducers.js
+++ b/packages/combat-sandbox/src/reducers.js
@@ -9,7 +9,7 @@ export function characterReducer(state, action) {
     case 'SPEND_ER':
       return { ...state, currentER: Math.max(0, state.currentER - action.amount) };
     case 'GAIN_ER':
-      return { ...state, currentER: Math.min(100, state.currentER + action.amount) };
+      return { ...state, currentER: Math.min(state.maxER, state.currentER + action.amount) };
     case 'PASSIVE_REGEN':
       return { ...state, currentER: Math.min(state.maxER, state.currentER + 1) };
     case 'TAKE_DAMAGE': {
@@ -19,7 +19,7 @@ export function characterReducer(state, action) {
 
       if (didDodge) {
         const erGain = action.dodgeErGain ?? 4;
-        const nextEr = Math.min(100, state.currentER + erGain);
+        const nextEr = Math.min(state.maxER, state.currentER + erGain);
         return {
           ...state,
           currentER: nextEr,
@@ -32,7 +32,7 @@ export function characterReducer(state, action) {
       return {
         ...state,
         hp: Math.max(0, state.hp - finalDamage),
-        currentER: Math.min(100, state.currentER + erGain)
+        currentER: Math.min(state.maxER, state.currentER + erGain)
       };
     }
     case 'HEAL':


### PR DESCRIPTION
## Summary
- cap character ER gains using their maxER value in all reducer branches
- add regression tests ensuring characters with higher maxER values cap correctly for direct gains and dodges

## Testing
- npm run test --workspace @tba-worldswithin/combat-sandbox *(fails: CombatSandbox component tests timeout in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3365082f0832ab621a1fe77cdb984