### PR TITLE
Clamp ER gain logs to actual energy awarded

### DIFF
--- a/packages/combat-sandbox/src/CombatSandbox.jsx
+++ b/packages/combat-sandbox/src/CombatSandbox.jsx
@@ -150,17 +150,21 @@ export function CombatSandbox({
         const dodgeTimestamp = getTimestamp();
         const didDodge = rollDodge(character.attributes.AGI);
         const dodgeErGain = 4;
+        const actualDodgeErGain = Math.max(
+          0,
+          Math.min(character.maxER - character.currentER, dodgeErGain)
+        );
         const erOnHit = 1;
         dispatchCharacter({
           type: 'TAKE_DAMAGE',
           amount: dmg,
           didDodge,
           dodgeTimestamp: didDodge ? dodgeTimestamp : undefined,
-          dodgeErGain,
+          dodgeErGain: actualDodgeErGain,
           erOnHit
         });
         if (didDodge) {
-          addLog(`Enemy attack dodged! +${dodgeErGain} ER`, 'er');
+          addLog(`Enemy attack dodged! +${actualDodgeErGain} ER`, 'er');
         } else {
           addLog(`Enemy hits for ${dmg} damage`, 'damage');
         }
@@ -209,8 +213,9 @@ export function CombatSandbox({
 
     const cost = calculateERCost(combatState.ability, character);
     const refund = cost.finalCost * 0.4;
-    dispatchCharacter({ type: 'GAIN_ER', amount: refund });
-    addLog(`Cancelled! Refunded ${refund.toFixed(1)} ER (40%)`, 'info');
+    const actualRefund = Math.max(0, Math.min(character.maxER - character.currentER, refund));
+    dispatchCharacter({ type: 'GAIN_ER', amount: actualRefund });
+    addLog(`Cancelled! Refunded ${actualRefund.toFixed(1)} ER (40%)`, 'info');
 
     setCombatState({ state: COMBAT_STATES.IDLE, ability: null, progress: 0, startTime: 0 });
   };
@@ -222,8 +227,13 @@ export function CombatSandbox({
     const elapsed = now - perfectTimingWindow.startTime;
 
     if (elapsed <= perfectTimingWindow.duration) {
-      dispatchCharacter({ type: 'GAIN_ER', amount: 4 });
-      addLog('PERFECT PARRY! +4 ER', 'er');
+      const intendedGain = 4;
+      const actualGain = Math.max(
+        0,
+        Math.min(character.maxER - character.currentER, intendedGain)
+      );
+      dispatchCharacter({ type: 'GAIN_ER', amount: actualGain });
+      addLog(`PERFECT PARRY! +${actualGain} ER`, 'er');
       setPerfectTimingWindow(null);
     } else {
       addLog('Too late! Perfect window missed', 'error');

--- a/packages/combat-sandbox/src/utils.js
+++ b/packages/combat-sandbox/src/utils.js
@@ -169,8 +169,12 @@ export const resolveCombatPhase = ({
 
     if (ability.variant === 'Attack') {
       const erGain = WEAPONS[character.weapon].erGainedOnHit || 2;
-      dispatchCharacter({ type: 'GAIN_ER', amount: erGain });
-      addLog(`+${erGain} ER`, 'er');
+      const actualErGain = Math.max(
+        0,
+        Math.min(character.maxER - character.currentER, erGain)
+      );
+      dispatchCharacter({ type: 'GAIN_ER', amount: actualErGain });
+      addLog(`+${actualErGain} ER`, 'er');
     } else if (ability.variant === 'Defense') {
       dispatchCharacter({ type: 'SET_DEFENSE', defense: ability });
       const perfectWindow = ability.perfectWindow || 0.3;
@@ -206,8 +210,13 @@ export const resolveCombatPhase = ({
         const timeSinceLastSuccess = (frameTimestamp - lastSuccess) / 1000;
 
         if (timeSinceLastSuccess >= 2.0) {
-          dispatchCharacter({ type: 'GAIN_ER', amount: 1 });
-          addLog('CC success! +1 ER (2s gate passed)', 'er');
+          const intendedErGain = 1;
+          const actualErGain = Math.max(
+            0,
+            Math.min(character.maxER - character.currentER, intendedErGain)
+          );
+          dispatchCharacter({ type: 'GAIN_ER', amount: actualErGain });
+          addLog(`CC success! +${actualErGain} ER (2s gate passed)`, 'er');
           setCcSuccessTimestamps((prev) => ({ ...prev, [ability.id]: frameTimestamp }));
         } else {
           addLog(`CC applied (ER gain on cooldown: ${(2.0 - timeSinceLastSuccess).toFixed(1)}s)`, 'info');


### PR DESCRIPTION
## Summary
- clamp ER gain amounts for dodge, cancel refunds, and perfect parries so logs reflect true energy awarded
- ensure attack hits and control CC success messages use the clamped ER value before dispatching the gain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3364f5360832aafe883e77a44c2aa