### PR TITLE
Enhance attribute guidance in combat sandbox

### DIFF
--- a/packages/combat-sandbox/src/CombatSandbox.jsx
+++ b/packages/combat-sandbox/src/CombatSandbox.jsx
@@ -6,6 +6,7 @@ import {
   ATTRIBUTE_DESCRIPTIONS,
   COMBAT_STATES,
   ELEMENTS,
+  ELEMENT_DESCRIPTIONS,
   LANE_STYLES,
   WEAPONS,
   initialCharacter,
@@ -439,42 +440,6 @@ export function CombatSandbox({
             Build Lab
           </h2>
 
-          <div className="mb-3 p-2 bg-purple-900 bg-opacity-30 rounded border border-purple-600">
-            <div className="text-xs font-semibold text-purple-300 mb-2">Quick Resonance Presets</div>
-            <div className="grid grid-cols-3 gap-1">
-              <button
-                type="button"
-                onClick={() => {
-                  dispatchCharacter({ type: 'SET_ATTRIBUTE', attr: 'STR', value: 50 });
-                  dispatchCharacter({ type: 'SET_ELEMENT', elem: 'Fire', value: 50 });
-                }}
-                className="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs"
-              >
-                STR×Fire 0.25
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  dispatchCharacter({ type: 'SET_ATTRIBUTE', attr: 'STR', value: 71 });
-                  dispatchCharacter({ type: 'SET_ELEMENT', elem: 'Fire', value: 71 });
-                }}
-                className="px-2 py-1 bg-purple-700 hover:bg-purple-600 rounded text-xs"
-              >
-                Bonded 0.50
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  dispatchCharacter({ type: 'SET_ATTRIBUTE', attr: 'STR', value: 90 });
-                  dispatchCharacter({ type: 'SET_ELEMENT', elem: 'Fire', value: 90 });
-                }}
-                className="px-2 py-1 bg-yellow-700 hover:bg-yellow-600 rounded text-xs"
-              >
-                Merged 0.81
-              </button>
-            </div>
-          </div>
-
           <div className="mb-3">
             <label className="text-xs font-semibold mb-1 block">Weapon</label>
             <select
@@ -546,6 +511,11 @@ export function CombatSandbox({
                 onChange={(e) => dispatchCharacter({ type: 'SET_ELEMENT', elem, value: parseInt(e.target.value, 10) })}
                 className="w-full h-1.5 rounded"
               />
+              {ELEMENT_DESCRIPTIONS[elem] ? (
+                <p className="mt-1 text-[10px] leading-tight text-gray-400">
+                  {ELEMENT_DESCRIPTIONS[elem]}
+                </p>
+              ) : null}
             </div>
           ))}
 

--- a/packages/combat-sandbox/src/constants.js
+++ b/packages/combat-sandbox/src/constants.js
@@ -1,7 +1,24 @@
 export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA', 'Impact'];
 
 export const ATTRIBUTE_DESCRIPTIONS = {
-  Impact: 'Boosts the payoff of damage abilities by amplifying the final damage multiplier for Attacks and Specials.'
+  STR: 'Strength lifts melee damage bonuses from +10% at tier 30 up to +40% at tier 90 and fuels Inferno Wave with Fire.',
+  DEX: 'Dexterity raises crit and off-hand reliability, peaking at +14% crit to spark Chain-Jump style reactions.',
+  TOU: 'Toughness adds flat physical damage reduction, climbing toward 8% while pairing with Stone for Charge-Armour.',
+  AGI: 'Agility shaves the global cooldown toward 0.75s and widens dodge rolls, unlocking Jet Dash with Air.',
+  SPR: 'Spirit amplifies restorative and cleansing payloads, empowering Water and Verdant resonance hooks.',
+  INS: 'Insight expands hidden-information reveals—from glow pings to Forecast—and supercharges Essence breaches.',
+  CHA: 'Charisma strengthens threat and aura broadcasts, sharing resonance boons across the party.',
+  Impact: 'Impact boosts the payoff of damage abilities by amplifying the final damage multiplier for Attacks and Specials.'
+};
+
+export const ELEMENT_DESCRIPTIONS = {
+  Fire: 'Fire embodies burn and empowerment themes—aggressive damage that peaks in Inferno Wave and lava reactions.',
+  Water: 'Water focuses on flow and cleansing support, turning resonance into sustain, debuff washes, and redirect stances.',
+  Stone: 'Stone is the fortify-and-impede element, layering mitigation, slows, and Charge-Armour bulwarks.',
+  Air: 'Air channels lift and displacement, rewarding high agility builds with mobility tricks like Jet Dash.',
+  Spark: 'Spark carries charge-and-jump energy, excelling at chained crit bursts and stun-laced openings.',
+  Verdant: 'Verdant nurtures regrowth and entanglement, blending damage with heals through living terrain effects.',
+  Essence: 'Essence manipulates soullight to infuse or transmute, enabling phase strikes and reality-tearing ultimates.'
 };
 
 export const ELEMENTS = ['Fire', 'Water', 'Stone', 'Air', 'Spark', 'Verdant', 'Essence'];


### PR DESCRIPTION
## Summary
- populate attribute descriptions for the build lab helper text
- add element flavor copy to the element sliders for additional context
- remove the hardcoded Quick Resonance preset buttons from the build lab panel

## Testing
- npm run test *(fails: CombatSandbox component tests time out under fake timers after removal of presets)*

------
https://chatgpt.com/codex/tasks/task_e_68e33d15d820832a8fc60faf975abb54