### PR TITLE
Document how to commit the Pages demo bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ npm run build
 
 Commit the generated `docs/demo/` contents and configure the repository to publish from the **docs/** folder. The hosted sandbox will be served from `https://<your-user>.github.io/WWComSan/demo/` alongside the existing Markdown documentation.
 
+```bash
+git add -A docs/demo
+git commit -m "Rebuild Pages demo"
+```
+
 ## Playing the sandbox
 
 * **Build Lab (left column):** adjust quick resonance presets, pick one of the 23 weapon types, and tweak every attribute/element slider to explore how resonance values shift. The live resonance panel surfaces thresholds for Bonded and Merged abilities so you know when higher tier skills unlock.

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -8,6 +8,10 @@
       name="description"
       content="Interactive Worlds Within combat sandbox hosted for GitHub Pages"
     />
+    <meta
+      name="build-tracking"
+      content="docs/demo refreshed to publish latest sandbox bundle"
+    />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <script type="module" crossorigin src="/WWComSan/demo/assets/index-B-gChdqC.js"></script>
     <link rel="stylesheet" crossorigin href="/WWComSan/demo/assets/index-DcDCN2Aq.css">


### PR DESCRIPTION
## Summary
- add a build-tracking meta tag to the published demo HTML so refreshed bundles are easy to verify
- document the git commands required to stage and commit `docs/demo` after rebuilding the Pages host

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e347dae64c832aa5956747a40d4b59