### PR TITLE
Clarify resonance copy and progression

### DIFF
--- a/packages/combat-sandbox/src/CombatSandbox.jsx
+++ b/packages/combat-sandbox/src/CombatSandbox.jsx
@@ -11,6 +11,7 @@ import {
   WEAPONS,
   WEAPON_TAGS,
   ELEMENT_DESCRIPTIONS,
+  ELEMENT_LANE_SYNERGY,
   initialCharacter,
   initialEnemy
 } from './constants.js';
@@ -37,6 +38,19 @@ const defaultSelectedAbilities = {
   defense: 'fire_defense',
   control: 'fire_control',
   special: 'fire_special'
+};
+
+const getNextResonanceTierTarget = (value) => {
+  if (value >= 0.7) {
+    return null;
+  }
+  if (value >= 0.5) {
+    return { label: 'Merged', threshold: 0.7 };
+  }
+  if (value >= 0.3) {
+    return { label: 'Bonded', threshold: 0.5 };
+  }
+  return { label: 'Touched', threshold: 0.3 };
 };
 
 function useCombatLog(initial = []) {
@@ -498,6 +512,9 @@ export function CombatSandbox({
 
         const top = resonances[0];
         const tier = getResonanceTier(top.value);
+        const elementDescription = ELEMENT_DESCRIPTIONS[elem];
+        const favoredLanes = ELEMENT_LANE_SYNERGY[elem] || [];
+        const nextTier = getNextResonanceTierTarget(top.value);
 
         return (
           <div key={elem} className="mb-2 p-2 bg-gray-800 rounded">
@@ -517,6 +534,31 @@ export function CombatSandbox({
                 {tier}
               </span>
             </div>
+            {elementDescription ? (
+              <p className="text-[11px] text-gray-300 mb-1 leading-snug">{elementDescription}</p>
+            ) : null}
+            {favoredLanes.length > 0 ? (
+              <div className="mb-2">
+                <p className="text-[10px] uppercase tracking-wide text-gray-400 mb-1">Favored lanes</p>
+                <div className="flex flex-wrap gap-1">
+                  {favoredLanes.map((lane) => (
+                    <span
+                      key={`${elem}-${lane}`}
+                      className="px-2 py-0.5 rounded-full bg-gray-700 text-[10px] font-semibold uppercase tracking-wide text-gray-200"
+                    >
+                      {lane}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {nextTier ? (
+              <p className="text-[11px] text-gray-300 mb-1">
+                Next tier at {nextTier.threshold.toFixed(2)} ({nextTier.label})
+              </p>
+            ) : (
+              <p className="text-[11px] text-amber-300 mb-1">Max resonance achieved</p>
+            )}
             <div className="text-xs text-gray-400">
               Best: {top.attr} {top.attrVal} × {elem} {top.elemVal} ={' '}
               <span className="font-mono text-white font-bold">{top.value.toFixed(3)}</span>

--- a/packages/combat-sandbox/src/constants.js
+++ b/packages/combat-sandbox/src/constants.js
@@ -1,24 +1,34 @@
 export const ATTRIBUTES = ['STR', 'DEX', 'TOU', 'AGI', 'SPR', 'INS', 'CHA', 'Impact'];
 
 export const ATTRIBUTE_DESCRIPTIONS = {
-  STR: 'Strength lifts melee damage bonuses from +10% at tier 30 up to +40% at tier 90 and fuels Inferno Wave with Fire.',
-  DEX: 'Dexterity raises crit and off-hand reliability, peaking at +14% crit to spark Chain-Jump style reactions.',
-  TOU: 'Toughness adds flat physical damage reduction, climbing toward 8% while pairing with Stone for Charge-Armour.',
-  AGI: 'Agility shaves the global cooldown toward 0.75s and widens dodge rolls, unlocking Jet Dash with Air.',
-  SPR: 'Spirit amplifies restorative and cleansing payloads, empowering Water and Verdant resonance hooks.',
-  INS: 'Insight expands hidden-information reveals—from glow pings to Forecast—and supercharges Essence breaches.',
-  CHA: 'Charisma strengthens threat and aura broadcasts, sharing resonance boons across the party.',
+  STR: 'Strength boosts melee damage scaling from roughly +10% at tier 30 to +40% at tier 90 while empowering Fire payoffs.',
+  DEX: 'Dexterity steadies crits and off-hand chains, topping out near +14% crit to spark rapid reactions.',
+  TOU: 'Toughness adds flat mitigation—closing on 8% reduction—and links with Stone for charge-armor tricks.',
+  AGI: 'Agility trims the global cooldown toward 0.75s and widens dodge timing to fuel Air mobility skills.',
+  SPR: 'Spirit magnifies heals and cleanses so Water and Verdant resonance loops deliver stronger sustain.',
+  INS: 'Insight broadens reveals and breach damage, feeding Essence manipulation and Forecast-style intel.',
+  CHA: 'Charisma heightens threat and aura reach, letting resonance boons pulse farther through the party.',
   Impact: 'Impact boosts the payoff of damage abilities by amplifying the final damage multiplier for Attacks and Specials.'
 };
 
 export const ELEMENT_DESCRIPTIONS = {
-  Fire: 'Fire embodies burn and empowerment themes—aggressive damage that peaks in Inferno Wave and lava reactions.',
-  Water: 'Water focuses on flow and cleansing support, turning resonance into sustain, debuff washes, and redirect stances.',
-  Stone: 'Stone is the fortify-and-impede element, layering mitigation, slows, and Charge-Armour bulwarks.',
-  Air: 'Air channels lift and displacement, rewarding high agility builds with mobility tricks like Jet Dash.',
-  Spark: 'Spark carries charge-and-jump energy, excelling at chained crit bursts and stun-laced openings.',
-  Verdant: 'Verdant nurtures regrowth and entanglement, blending damage with heals through living terrain effects.',
-  Essence: 'Essence manipulates soullight to infuse or transmute, enabling phase strikes and reality-tearing ultimates.'
+  Fire: 'Fire leans into burn and empowerment loops—fast damage spikes that crest in Inferno Wave payoffs.',
+  Water: 'Water channels flow and cleansing support, turning resonance into sustain, washes, and redirects.',
+  Stone: 'Stone fortifies and impedes, layering mitigation, slows, and charge-armor bulwarks for stalwart play.',
+  Air: 'Air thrives on lift and displacement, rewarding agility with reposition tools like Jet Dash and gusts.',
+  Spark: 'Spark fuels charged crit chains and stuns, thriving when actions jump between clustered targets.',
+  Verdant: 'Verdant cultivates regrowth and binds, mixing damage with heals through living terrain resonance.',
+  Essence: 'Essence manipulates soullight to infuse or transmute, enabling phase strikes and reality bends.'
+};
+
+export const ELEMENT_LANE_SYNERGY = {
+  Fire: ['Attack', 'Special'],
+  Water: ['Defense', 'Special'],
+  Stone: ['Defense', 'Control'],
+  Air: ['Attack', 'Control'],
+  Spark: ['Attack', 'Special'],
+  Verdant: ['Control', 'Special'],
+  Essence: ['Attack', 'Special']
 };
 
 export const ELEMENTS = ['Fire', 'Water', 'Stone', 'Air', 'Spark', 'Verdant', 'Essence'];


### PR DESCRIPTION
## Summary
- tighten attribute and element helper copy so every slider explains its impact in-line
- expand resonance detail cards with favored lane badges and next-tier guidance for each element
- add a helper to flag the upcoming resonance threshold when tiers remain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e36a9d2318832a859a633d76e463f5